### PR TITLE
Fix: strip newline characters from single-line text fields (#86)

### DIFF
--- a/basicwidget/text.go
+++ b/basicwidget/text.go
@@ -686,6 +686,10 @@ func (t *Text) HandleButtonInput(context *guigui.Context) guigui.HandleInputResu
 				slog.Error(err.Error())
 				return guigui.AbortHandlingInputByWidget(t)
 			}
+			if !t.multiline { // Ensure single-line constraint
+				ct = strings.ReplaceAll(ct, "\n", "")
+				ct = strings.ReplaceAll(ct, "\r", "")
+			}
 			text := t.field.Text()[:start] + ct + t.field.Text()[end:]
 			t.setTextAndSelection(text, start+len(ct), start+len(ct), -1)
 			return guigui.HandleInputByWidget(t)


### PR DESCRIPTION
Summary
Fixes #86 by stripping newline (\n) and carriage return (\r) characters from pasted input in single-line TextField widgets.

Changes
Sanitizes pasted content when !t.multiline to enforce single-line input constraints.